### PR TITLE
Re-order middleware so that it doesn't effect CSRF tokens

### DIFF
--- a/src/app/create-app.js
+++ b/src/app/create-app.js
@@ -52,6 +52,7 @@ module.exports = function () {
     }))
   }
 
+  app.use(cookieParser())
   app.use(session({
     store: new MemoryStore({
       checkPeriod: 86400000,
@@ -62,16 +63,19 @@ module.exports = function () {
       maxAge: config.session.ttl,
     },
     secret: config.session.secret,
+    key: 'datahub_omis.sid',
+    rolling: false,
+    resave: false,
+    saveUninitialized: true,
   }))
+  app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
 
   app.use(setLocals)
-  app.use(cookieParser())
-  app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
-  app.use(csrf())
-  app.use(setCSRFToken())
   app.use(morganLogger((isDev ? 'dev' : 'combined')))
   app.use(headers(isDev))
   app.use(ping)
+  app.use(csrf({ cookie: true }))
+  app.use(setCSRFToken())
 
   app.use(router)
 


### PR DESCRIPTION
The cookie-parser middleware needs to be called before the session
store in order for the CSRF middleware to work correctly.

This work changes the order to fix this problem.