### PR TITLE
Add messaging for how to get legacy documents

### DIFF
--- a/src/app/views/order-summary.njk
+++ b/src/app/views/order-summary.njk
@@ -27,6 +27,12 @@
       <p>
         <a href="/{{ publicToken }}/invoice">View your invoice</a>
       </p>
+    {% else %}
+      {% call Reveal({ summary: 'How can I see my invoice?' }) %}
+        {% call Message({ type: 'muted' }) %}
+          Get in touch with your DIT contact or email <a href="mailto:omis.orders@digital.trade.gov.uk">omis.orders@digital.trade.gov.uk</a>
+        {% endcall %}
+      {% endcall %}
     {% endif %}
 
     {% if order.status in ['paid', 'complete'] %}

--- a/src/app/views/quote.njk
+++ b/src/app/views/quote.njk
@@ -51,6 +51,12 @@
         {% endcall %}
       </div>
     </article>
+  {% else %}
+    {% call Reveal({ summary: 'How can I see my quote?' }) %}
+      {% call Message({ type: 'muted' }) %}
+        Get in touch with your DIT contact or email <a href="mailto:omis.orders@digital.trade.gov.uk">omis.orders@digital.trade.gov.uk</a>
+      {% endcall %}
+    {% endcall %}
   {% endif %}
 
   {% if not quote.expired and not quote.accepted_on and not quote.cancelled_on %}


### PR DESCRIPTION
This adds some content explaining how users can get in contact
with us to get their original quote or invoice.