### PR TITLE
Enable sentry

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -41,6 +41,7 @@ const config = {
     dateTimeLong: 'D MMMM YYYY, h:mma',
     dateTimeMedium: 'D MMM YYYY, h:mma',
   },
+  sentryDsn: process.env.SENTRY_DSN,
 }
 
 module.exports = config


### PR DESCRIPTION
This adds `sentryDsn` to config so that it can be set using the environment variable `SENTRY_DSN`.