### PR TITLE
Ping without token

### DIFF
--- a/src/app/create-app.js
+++ b/src/app/create-app.js
@@ -15,7 +15,6 @@ const nunjucks = require('../../config/nunjucks')
 const router = require('./router')
 const reporter = require('./lib/reporter')
 
-const ping = require('./middleware/ping')
 const headers = require('./middleware/headers')
 const errors = require('./middleware/errors')
 const setCSRFToken = require('./middleware/set-csrf-token')
@@ -73,7 +72,6 @@ module.exports = function () {
   app.use(setLocals)
   app.use(morganLogger((isDev ? 'dev' : 'combined')))
   app.use(headers(isDev))
-  app.use(ping)
   app.use(csrf({ cookie: true }))
   app.use(setCSRFToken())
 

--- a/src/app/middleware/ping.js
+++ b/src/app/middleware/ping.js
@@ -1,8 +1,0 @@
-module.exports = function (req, res, next) {
-  if (req.url === '/ping/') {
-    res.status(200)
-    res.end()
-  } else {
-    next()
-  }
-}

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -9,11 +9,12 @@ const { renderReceipt } = require('./controllers/receipt')
 const { fetchOrderDetails } = require('./middleware/order')
 const { setAuthToken } = require('./lib/api')
 
+// NOTE: ping has to be defined before the auth token middleware
+router.get('/ping.xml', renderPingdomXml)
+
 router.use(setAuthToken())
 
 router.get('/', indexController)
-
-router.get('/ping.xml', renderPingdomXml)
 
 router.param(':publicToken', fetchOrderDetails)
 


### PR DESCRIPTION
**Before:**
An auth token was requested and created every time /ping.xml was called because of the auth middleware.

**After:**
The ping route is now defined before anything else so that no token is requested or created.

I've also deleted legacy files.