### PR TITLE
Add support for a Google Tag Manager suffix

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -43,6 +43,7 @@ const config = {
   },
   sentryDsn: process.env.SENTRY_DSN,
   googleTagManagerKey: process.env.GOOGLE_TAG_MANAGER_KEY,
+  googleTagManagerSuffix: process.env.GOOGLE_TAG_MANAGER_SUFFIX,
 }
 
 module.exports = config

--- a/src/app/middleware/set-locals.js
+++ b/src/app/middleware/set-locals.js
@@ -16,6 +16,7 @@ module.exports = function setLocals (req, res, next) {
     CANONICAL_URL: baseUrl + req.originalUrl,
     CURRENT_PATH: req.path,
     GOOGLE_TAG_MANAGER_KEY: config.googleTagManagerKey,
+    GOOGLE_TAG_MANAGER_SUFFIX: config.googleTagManagerSuffix,
 
     getMessages () {
       return req.flash()

--- a/src/app/views/_layouts/omis-base.njk
+++ b/src/app/views/_layouts/omis-base.njk
@@ -13,7 +13,7 @@
         var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),
             dl=l!='dataLayer'?'&l='+l:'';
-        j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+        j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'{{ GOOGLE_TAG_MANAGER_SUFFIX | safe }}';
         f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','{{ GOOGLE_TAG_MANAGER_KEY }}');
     </script>
@@ -23,7 +23,7 @@
 {% block body %}
   {% if GOOGLE_TAG_MANAGER_KEY %}
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER_KEY }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      <iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER_KEY }}{{ GOOGLE_TAG_MANAGER_SUFFIX | safe }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
   {% endif %}
 


### PR DESCRIPTION
This suffix is to be used for certain environments to help distinguish
them.

It is being marked as safe as will be coming from a variable set on
that environment and can be treated safely.