### PR TITLE
Link invoice from quote accepted summary

### DIFF
--- a/src/app/views/quote-accepted.njk
+++ b/src/app/views/quote-accepted.njk
@@ -16,7 +16,7 @@
 
   <p>You will receive a confirmation email that the quote has been accepted.</p>
 
-  <p>You will need to pay the invoice within 30 days.</p>
+  <p>You will need to pay <a href="/{{ publicToken }}/invoice">the invoice</a> by {{ invoice.payment_due_date | formatDate }} ({{ invoice.payment_due_date | fromNow }}).</p>
 
   <p>
     <a href="/{{ publicToken }}">Return to summary</a>


### PR DESCRIPTION
After a quote has been accepted we can create a link directly to the
invoice and also display the date that the invoice needs to be paid
by.