### PR TITLE
Add canonical URL to head

### DIFF
--- a/src/app/middleware/set-locals.js
+++ b/src/app/middleware/set-locals.js
@@ -13,7 +13,7 @@ module.exports = function setLocals (req, res, next) {
 
   res.locals = Object.assign({}, res.locals, {
     BASE_URL: baseUrl,
-    CANONICAL_URL: baseUrl + req.originalUrl,
+    CANONICAL_URL: baseUrl + req.path,
     CURRENT_PATH: req.path,
     GOOGLE_TAG_MANAGER_KEY: config.googleTagManagerKey,
     GOOGLE_TAG_MANAGER_SUFFIX: config.googleTagManagerSuffix,

--- a/src/app/views/_layouts/dit-base.njk
+++ b/src/app/views/_layouts/dit-base.njk
@@ -11,6 +11,10 @@
         <meta name="description" content="{{ description }}">
       {% endif -%}
 
+      {% if CANONICAL_URL %}
+        <link rel="canonical" href="{{ CANONICAL_URL }}">
+      {% endif %}
+
       {% block head_content %}
         <!--[if IE]><link rel="shortcut icon" href="{{ getAssetPath('images/favicon.ico') }}" type="image/x-icon"><![endif]-->
         <!-- Touch Icons - iOS and Android 2.1+ 180x180 pixels in size. -->


### PR DESCRIPTION
This adds a canonical URL item to the head so that analytics doesn't
get flooded with duplicate URLs when they contain query strings.