### PR TITLE
Ensure zero is formatted as a currency

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -50,9 +50,6 @@ const filters = {
   },
 
   formatCurrency: (value, format = formats.currency) => {
-    if (!value) {
-      return value
-    }
     return numeral(value).format(format)
   },
 


### PR DESCRIPTION
Zero is a valid value when formatting currencies so we should change
the current early return to allow zero as a value.