### PR TITLE
Convert expiry date to a datetime with 23:59:59 as expiry time

### DIFF
--- a/src/app/middleware/order.js
+++ b/src/app/middleware/order.js
@@ -22,7 +22,8 @@ async function fetchOrderDetails (req, res, next, publicToken) {
 
   try {
     quote = await fetch(authToken, `/v3/omis/public/order/${publicToken}/quote`)
-    quote.expired = new Date(quote.expires_on) < new Date()
+    quote.expires_on = new Date(quote.expires_on + 'T23:59:59')
+    quote.expired = quote.expires_on < new Date()
 
     invoice = await fetch(authToken, `/v3/omis/public/order/${publicToken}/invoice`)
   } catch (error) {


### PR DESCRIPTION
This ensures that the relative time displayed is until the end of the
current day and that the quote does not show expired if the current
date is the expiry date.