### PR TITLE
Use the dynamic payment due date for invoices

### DIFF
--- a/src/app/views/invoice.njk
+++ b/src/app/views/invoice.njk
@@ -61,7 +61,7 @@
 
   <h3>Payment terms</h3>
 
-  <p>Payable within 30 days. For events, 10 working days before event date.</p>
+  <p>Payable by {{ invoice.payment_due_date | formatDate }} ({{ invoice.payment_due_date | fromNow }}).</p>
 
   <h3>How to pay by bank transfer</h3>
 


### PR DESCRIPTION
The payment due date is provided by the API. This change makes use of
that rather than generic payment terms.

## What it looks like

![image](https://user-images.githubusercontent.com/3327997/35819796-a531243e-0a9b-11e8-8ab0-2f056f5c67ad.png)
