### PR TITLE
Remove deprecated router.param method

### DIFF
--- a/src/app/controllers/quote.js
+++ b/src/app/controllers/quote.js
@@ -19,7 +19,6 @@ async function acceptQuote (req, res, next) {
   const authToken = req.session.token
 
   if (!get(req.body, 'confirm')) {
-    console.log('DOING')
     res.locals.invalid = true
     return next()
   }

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -16,7 +16,7 @@ router.use(setAuthToken())
 
 router.get('/', indexController)
 
-router.param(':publicToken', fetchOrderDetails)
+router.param('publicToken', fetchOrderDetails)
 
 router.get('/:publicToken', renderOrderSummary)
 


### PR DESCRIPTION
Previously called param middleware using a colon prefix.

This method has been deprecated so this change replaces it with
the desired method.

This change also includes removing a stray `console.log` statement.