### PR TITLE
Use reading width container for index page

### DIFF
--- a/src/app/views/index.njk
+++ b/src/app/views/index.njk
@@ -2,7 +2,7 @@
 
 {% set pageTitle='Homepage' %}
 
-{% block body_main_content %}
+{% block main_content %}
   <h1>About this service</h1>
 
   <p>The Overseas Market Introduction Service (OMIS) can help you find overseas customers using the Department for International Trade’s (DIT) network of trade specialists. Find out more about <a href="https://www.gov.uk/overseas-customers-export-opportunities/trade-specialist-help">getting help from a trade specialist</a>.</p>


### PR DESCRIPTION
This route was missed when setting a base reading with on basic
content pages.