### PR TITLE
Fix use of public token in quote router

### DIFF
--- a/src/app/controllers/quote.js
+++ b/src/app/controllers/quote.js
@@ -8,14 +8,14 @@ function renderQuote (req, res, next) {
 
 function renderAcceptedQuote (req, res, next) {
   if (!res.locals.quote.accepted_on) {
-    return res.redirect(`/${req.params.publicToken}/quote`)
+    return res.redirect(`/${res.locals.publicToken}/quote`)
   }
 
   res.render('quote-accepted')
 };
 
 async function acceptQuote (req, res, next) {
-  const publicToken = req.params.publicToken
+  const publicToken = res.locals.publicToken
   const authToken = req.session.token
 
   if (!get(req.body, 'confirm')) {


### PR DESCRIPTION
Parts of this journey used the request param to get the public token.

As the routers have been nested this value is now not available to
these controllers.

This change uses the order on locals that is available to all
controllers and middleware.