### PR TITLE
Fix flakey test

### DIFF
--- a/src/test/app/specs/config.spec.js
+++ b/src/test/app/specs/config.spec.js
@@ -73,7 +73,7 @@ describe('Config', function () {
         process.env.SERVER_WORKERS = 3
         const config = createConfig()
 
-        expect(config.server.workers).toEqual(3)
+        expect(parseInt(config.server.workers)).toEqual(3)
       })
     })
 


### PR DESCRIPTION
The config unit test sometimes returns a string but checks for
an integer.

This change converts the value to test against into the same type
before checking.