### PR TITLE
Create payment gateway session

### DIFF
--- a/assets/stylesheets/layout/_assemblies.scss
+++ b/assets/stylesheets/layout/_assemblies.scss
@@ -48,7 +48,7 @@ h2, h3, h4, h5 {
 }
 
 p + p {
-  margin-top: $default-spacing-unit / 2;
+  margin-top: $default-spacing-unit;
 }
 
 .u-clearfix {

--- a/src/app/middleware/payment.js
+++ b/src/app/middleware/payment.js
@@ -1,5 +1,6 @@
 const { get } = require('lodash')
 
+const { fetch } = require('../lib/api')
 const { isProd, showPaymentJourney } = require('../../../config')
 
 function checkOrderStatus (req, res, next) {
@@ -25,7 +26,26 @@ function checkPaidStatus (req, res, next) {
   next()
 }
 
+async function createPaymentGatewaySession (req, res, next) {
+  const publicToken = res.locals.publicToken
+  const authToken = req.session.token
+
+  try {
+    const gatewaySession = await fetch(authToken, {
+      method: 'post',
+      url: `/v3/omis/public/order/${publicToken}/payment-gateway-session`,
+    })
+
+    res.locals.paymentUrl = gatewaySession.payment_url
+
+    next()
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
   checkOrderStatus,
   checkPaidStatus,
+  createPaymentGatewaySession,
 }

--- a/src/app/routers/payment.js
+++ b/src/app/routers/payment.js
@@ -9,6 +9,7 @@ const {
 const {
   checkOrderStatus,
   checkPaidStatus,
+  createPaymentGatewaySession,
 } = require('../middleware/payment')
 
 router.use(checkOrderStatus, checkPaidStatus)
@@ -18,7 +19,7 @@ router
   .get(renderPaymentOptions)
   .post(handlePaymentOptions)
 
-router.get('/card', renderCardMethod)
+router.get('/card', createPaymentGatewaySession, renderCardMethod)
 router.get('/bank-transfer', renderBankTransferMethod)
 
 module.exports = router

--- a/src/app/views/payment/card.njk
+++ b/src/app/views/payment/card.njk
@@ -10,9 +10,7 @@
     <strong>{{ order.total_cost | formatCurrency }}</strong>
   </p>
 
-  <form method="post">
-    <input type="hidden" name="_csrf" value="{{ CSRF_TOKEN }}">
-
-    <button type="submit" class="button">Continue to secure payment</button>
-  </form>
+  <p>
+    <a href="{{ paymentUrl }}" class="button">Continue to secure payment</a>
+  </p>
 {% endblock %}


### PR DESCRIPTION
This change creats a payment gateway session to redirect the
payment journey to on a `GET` of the card payment step.

It also updates the card view to simply include a link that is
now set within a piece of middleware rather than containing a
form that posts back to itself.