### PR TITLE
Only store payment gateway session ID in session

### DIFF
--- a/src/app/middleware/payment.js
+++ b/src/app/middleware/payment.js
@@ -27,7 +27,7 @@ function checkPaidStatus (req, res, next) {
 }
 
 async function createPaymentGatewaySession (req, res, next) {
-  if (get(req, 'paymentGatewaySession.payment_url')) {
+  if (get(req, 'paymentGatewaySession.id')) {
     return next()
   }
 
@@ -35,10 +35,30 @@ async function createPaymentGatewaySession (req, res, next) {
     const publicToken = res.locals.publicToken
     const authToken = req.session.token
 
-    req.paymentGatewaySession = await fetch(authToken, {
+    const paymentGatewaySession = await fetch(authToken, {
       method: 'post',
       url: `/v3/omis/public/order/${publicToken}/payment-gateway-session`,
     })
+
+    req.paymentGatewaySession.id = paymentGatewaySession.id
+    next()
+  } catch (error) {
+    next(error)
+  }
+}
+
+async function setPaymentGatewaySession (req, res, next) {
+  const sessionId = get(req, 'paymentGatewaySession.id')
+
+  if (!sessionId) {
+    return next()
+  }
+
+  try {
+    const publicToken = res.locals.publicToken
+    const authToken = req.session.token
+
+    res.locals.paymentGatewaySession = await fetch(authToken, `/v3/omis/public/order/${publicToken}/payment-gateway-session/${sessionId}`)
 
     next()
   } catch (error) {
@@ -46,14 +66,9 @@ async function createPaymentGatewaySession (req, res, next) {
   }
 }
 
-function setPaymentGatewayUrl (req, res, next) {
-  res.locals.paymentGatewayUrl = get(req, 'paymentGatewaySession.payment_url')
-  next()
-}
-
 module.exports = {
   checkOrderStatus,
   checkPaidStatus,
   createPaymentGatewaySession,
-  setPaymentGatewayUrl,
+  setPaymentGatewaySession,
 }

--- a/src/app/routers/payment.js
+++ b/src/app/routers/payment.js
@@ -10,7 +10,7 @@ const {
   checkOrderStatus,
   checkPaidStatus,
   createPaymentGatewaySession,
-  setPaymentGatewayUrl,
+  setPaymentGatewaySession,
 } = require('../middleware/payment')
 
 router.use(checkOrderStatus, checkPaidStatus)
@@ -22,7 +22,7 @@ router
 
 router.get('/card',
   createPaymentGatewaySession,
-  setPaymentGatewayUrl,
+  setPaymentGatewaySession,
   renderCardMethod
 )
 router.get('/bank-transfer', renderBankTransferMethod)

--- a/src/app/views/payment/card.njk
+++ b/src/app/views/payment/card.njk
@@ -11,6 +11,6 @@
   </p>
 
   <p>
-    <a href="{{ paymentGatewayUrl }}" class="button">Continue to secure payment</a>
+    <a href="{{ paymentGatewaySession.payment_url }}" class="button">Continue to secure payment</a>
   </p>
 {% endblock %}


### PR DESCRIPTION
This refactor only stores the payment gateway session ID in the
users session rather than the whole object. It then checks the API
again using this ID to get the latest state and payment URL of this
payment session.

This will also be used in following changes to checkt the status
of the payment session and handle it appropriately for possible
edge cases.