### PR TITLE
Handle GOV.UK Pay return journey

### DIFF
--- a/src/app/controllers/payment.js
+++ b/src/app/controllers/payment.js
@@ -35,6 +35,10 @@ function renderCardSuccess (req, res) {
   res.render('payment/success')
 }
 
+function redirectReturnUrl (req, res) {
+  res.redirect(`/${res.locals.publicToken}/payment/card`)
+}
+
 module.exports = {
   renderPaymentOptions,
   handlePaymentOptions,
@@ -42,4 +46,5 @@ module.exports = {
   renderCardMethod,
   renderCardFailure,
   renderCardSuccess,
+  redirectReturnUrl,
 }

--- a/src/app/controllers/payment.js
+++ b/src/app/controllers/payment.js
@@ -27,9 +27,19 @@ function renderCardMethod (req, res) {
   res.render('payment/card')
 }
 
+function renderCardFailure (req, res) {
+  res.render('payment/failure')
+}
+
+function renderCardSuccess (req, res) {
+  res.render('payment/success')
+}
+
 module.exports = {
   renderPaymentOptions,
   handlePaymentOptions,
   renderBankTransferMethod,
   renderCardMethod,
+  renderCardFailure,
+  renderCardSuccess,
 }

--- a/src/app/middleware/payment.js
+++ b/src/app/middleware/payment.js
@@ -79,10 +79,24 @@ function checkPaymentGatewaySessionStatus (req, res, next) {
   next()
 }
 
+function validatePaymentGatewaySession (req, res, next) {
+  const publicToken = res.locals.publicToken
+  const requestSessionId = req.params.paymentSessionId
+  const sessionCookieId = get(req, `paymentGatewaySession.${publicToken}`)
+
+  if (sessionCookieId !== requestSessionId) {
+    req.paymentGatewaySession = {}
+    return res.redirect(`/${publicToken}/payment/card/failure`)
+  }
+
+  next()
+}
+
 module.exports = {
   checkOrderStatus,
   checkPaidStatus,
   createPaymentGatewaySession,
   setPaymentGatewaySession,
   checkPaymentGatewaySessionStatus,
+  validatePaymentGatewaySession,
 }

--- a/src/app/middleware/payment.js
+++ b/src/app/middleware/payment.js
@@ -63,9 +63,26 @@ async function setPaymentGatewaySession (req, res, next) {
   }
 }
 
+function checkPaymentGatewaySessionStatus (req, res, next) {
+  const publicToken = res.locals.publicToken
+  const status = get(res.locals, 'paymentGatewaySession.status')
+
+  if (status === 'success') {
+    return res.redirect(`/${publicToken}/payment/card/success`)
+  }
+
+  if (['failed', 'cancelled', 'error'].includes(status)) {
+    req.paymentGatewaySession = {}
+    return res.redirect(`/${publicToken}/payment/card/failure`)
+  }
+
+  next()
+}
+
 module.exports = {
   checkOrderStatus,
   checkPaidStatus,
   createPaymentGatewaySession,
   setPaymentGatewaySession,
+  checkPaymentGatewaySessionStatus,
 }

--- a/src/app/middleware/payment.js
+++ b/src/app/middleware/payment.js
@@ -42,6 +42,10 @@ async function createPaymentGatewaySession (req, res, next) {
     req.paymentGatewaySession[publicToken] = paymentGatewaySession.id
     next()
   } catch (error) {
+    if (error.statusCode === 409) {
+      return res.redirect(`/${publicToken}/payment`)
+    }
+
     next(error)
   }
 }

--- a/src/app/middleware/payment.js
+++ b/src/app/middleware/payment.js
@@ -48,7 +48,7 @@ async function createPaymentGatewaySession (req, res, next) {
 
 async function setPaymentGatewaySession (req, res, next) {
   const publicToken = res.locals.publicToken
-  const sessionId = get(req, `paymentGatewaySession.${publicToken}`)
+  const sessionId = req.params.paymentSessionId || get(req, `paymentGatewaySession.${publicToken}`)
 
   if (!sessionId) {
     return next()

--- a/src/app/routers/payment.js
+++ b/src/app/routers/payment.js
@@ -13,6 +13,7 @@ const {
   checkPaidStatus,
   createPaymentGatewaySession,
   setPaymentGatewaySession,
+  checkPaymentGatewaySessionStatus,
 } = require('../middleware/payment')
 
 router.use(checkOrderStatus, checkPaidStatus)
@@ -27,6 +28,7 @@ router.get('/bank-transfer', renderBankTransferMethod)
 router.get('/card',
   createPaymentGatewaySession,
   setPaymentGatewaySession,
+  checkPaymentGatewaySessionStatus,
   renderCardMethod
 )
 router.get('/card/failure', renderCardFailure)

--- a/src/app/routers/payment.js
+++ b/src/app/routers/payment.js
@@ -7,6 +7,7 @@ const {
   renderBankTransferMethod,
   renderCardFailure,
   renderCardSuccess,
+  redirectReturnUrl,
 } = require('../controllers/payment')
 const {
   checkOrderStatus,
@@ -30,6 +31,12 @@ router.get('/card',
   setPaymentGatewaySession,
   checkPaymentGatewaySessionStatus,
   renderCardMethod
+)
+router.get('/card/:paymentSessionId',
+  validatePaymentGatewaySession,
+  setPaymentGatewaySession,
+  checkPaymentGatewaySessionStatus,
+  redirectReturnUrl
 )
 router.get('/card/failure', renderCardFailure)
 router.get('/card/success', renderCardSuccess)

--- a/src/app/routers/payment.js
+++ b/src/app/routers/payment.js
@@ -5,6 +5,8 @@ const {
   handlePaymentOptions,
   renderCardMethod,
   renderBankTransferMethod,
+  renderCardFailure,
+  renderCardSuccess,
 } = require('../controllers/payment')
 const {
   checkOrderStatus,
@@ -20,11 +22,14 @@ router
   .get(renderPaymentOptions)
   .post(handlePaymentOptions)
 
+router.get('/bank-transfer', renderBankTransferMethod)
+
 router.get('/card',
   createPaymentGatewaySession,
   setPaymentGatewaySession,
   renderCardMethod
 )
-router.get('/bank-transfer', renderBankTransferMethod)
+router.get('/card/failure', renderCardFailure)
+router.get('/card/success', renderCardSuccess)
 
 module.exports = router

--- a/src/app/routers/payment.js
+++ b/src/app/routers/payment.js
@@ -18,7 +18,20 @@ const {
   validatePaymentGatewaySession,
 } = require('../middleware/payment')
 
-router.use(checkOrderStatus, checkPaidStatus)
+router.use(checkOrderStatus)
+
+router.get('/card/failure', renderCardFailure)
+router.get('/card/success', renderCardSuccess)
+router.get('/card/:paymentSessionId',
+  validatePaymentGatewaySession,
+  setPaymentGatewaySession,
+  checkPaymentGatewaySessionStatus,
+  redirectReturnUrl
+)
+
+// Placed specifically to prevent beginning of journey
+// being access if order has been paid
+router.use(checkPaidStatus)
 
 router
   .route('/')
@@ -33,13 +46,5 @@ router.get('/card',
   checkPaymentGatewaySessionStatus,
   renderCardMethod
 )
-router.get('/card/:paymentSessionId',
-  validatePaymentGatewaySession,
-  setPaymentGatewaySession,
-  checkPaymentGatewaySessionStatus,
-  redirectReturnUrl
-)
-router.get('/card/failure', renderCardFailure)
-router.get('/card/success', renderCardSuccess)
 
 module.exports = router

--- a/src/app/routers/payment.js
+++ b/src/app/routers/payment.js
@@ -15,6 +15,7 @@ const {
   createPaymentGatewaySession,
   setPaymentGatewaySession,
   checkPaymentGatewaySessionStatus,
+  validatePaymentGatewaySession,
 } = require('../middleware/payment')
 
 router.use(checkOrderStatus, checkPaidStatus)

--- a/src/app/views/payment/failure.njk
+++ b/src/app/views/payment/failure.njk
@@ -1,0 +1,11 @@
+{% extends '_layouts/omis-base.njk' %}
+
+{% block main_content %}
+  <h1>Your payment failed</h1>
+
+  <p>There was a problem with the secure payment provider. No money has been taken from your account.</p>
+
+  <p>
+    <a href="/{{ publicToken }}/payment/card" class="button">Try the payment again</a>
+  </p>
+{% endblock %}

--- a/src/app/views/payment/success.njk
+++ b/src/app/views/payment/success.njk
@@ -1,0 +1,22 @@
+{% extends '_layouts/omis-base.njk' %}
+
+{% block main_content %}
+  <div class="confirmation-banner">
+    <h1 class="confirmation-banner__heading">
+      Payment successful
+    </h1>
+
+    <p>
+      Your reference number is
+      <strong class="confirmation-banner__referene">
+        {{ order.reference }}
+      </strong>
+    </p>
+  </div>
+
+  <h3>What happens next</h3>
+
+  <p>You will receive a confirmation email that your payment has been received.</p>
+
+  <p><a href="/{{ publicToken }}/receipt">View your payment receipt</a></p>
+{% endblock %}


### PR DESCRIPTION
This contains the logic needed to handle the return journey from GOV.UK Pay.

It contains some logic around what to do when the payment gateway session is in
different states and when the requested ID doesn't match the ID stored in the
session cookie.