### PR TITLE
Update content for payment options

### DIFF
--- a/src/app/views/payment/bank-transfer.njk
+++ b/src/app/views/payment/bank-transfer.njk
@@ -12,6 +12,6 @@
   <h3>Can't pay by bank transfer</h3>
 
   <p>
-    Alternatively, you can <a href="/{{ publicToken }}/payment/card">pay by card</a>.
+    Alternatively, you can <a href="/{{ publicToken }}/payment/card">pay by credit or debit card</a>.
   </p>
 {% endblock %}

--- a/src/app/views/payment/bank-transfer.njk
+++ b/src/app/views/payment/bank-transfer.njk
@@ -9,7 +9,7 @@
     <a href="/{{ publicToken }}/invoice">View your invoice</a>
   </p>
 
-  <h3>Can't pay by bank transfer</h3>
+  <h3>Can’t pay by bank transfer</h3>
 
   <p>
     Alternatively, you can <a href="/{{ publicToken }}/payment/card">pay by credit or debit card</a>.

--- a/src/app/views/payment/card.njk
+++ b/src/app/views/payment/card.njk
@@ -13,4 +13,10 @@
   <p>
     <a href="{{ paymentGatewaySession.payment_url }}" class="button">Continue to secure payment service</a>
   </p>
+
+  <h3>Can’t pay by credit or debit card</h3>
+
+  <p>
+    Alternatively, you can <a href="/{{ publicToken }}/payment/bank-transfer">pay by bank transfer</a>.
+  </p>
 {% endblock %}

--- a/src/app/views/payment/card.njk
+++ b/src/app/views/payment/card.njk
@@ -11,6 +11,6 @@
   </p>
 
   <p>
-    <a href="{{ paymentGatewaySession.payment_url }}" class="button">Continue to secure payment</a>
+    <a href="{{ paymentGatewaySession.payment_url }}" class="button">Continue to secure payment service</a>
   </p>
 {% endblock %}

--- a/src/app/views/payment/paid.njk
+++ b/src/app/views/payment/paid.njk
@@ -1,9 +1,13 @@
 {% extends '_layouts/omis-base.njk' %}
 
 {% block main_content %}
-  <h1>Your order has already been paid</h1>
+  <p class="u-print-hide">
+    <a href="/{{ publicToken }}">Back to summary</a>
+  </p>
 
-  <p>Your payment was received on {{ order.paid_on | formatDateTime }}.</p>
+  <h1>Your order has already been paid for</h1>
+
+  <p>Your payment was received on {{ order.paid_on | formatDate }}.</p>
 
   <p>
     <a href="/{{ publicToken }}/receipt">View your payment receipt</a>


### PR DESCRIPTION
This ensures we consistently say credit and debit for card payments
and makes the button text for continuing to the payment provider
more readable.

It also ensures we're consistent with providing alternative routes when on
a particular option page and that the order already paid page has a route
back to the summary.