### PR TITLE
Ensure payment redirects are absolute

### DIFF
--- a/src/app/controllers/payment.js
+++ b/src/app/controllers/payment.js
@@ -4,13 +4,14 @@ function renderPaymentOptions (req, res) {
 
 function handlePaymentOptions (req, res) {
   const paymentMethod = req.body['payment-method']
+  const publicToken = res.locals.publicToken
 
   if (paymentMethod === 'card') {
-    return res.redirect('payment/card')
+    return res.redirect(`/${publicToken}/payment/card`)
   }
 
   if (paymentMethod === 'bank-transfer') {
-    return res.redirect('payment/bank-transfer')
+    return res.redirect(`/${publicToken}/payment/bank-transfer`)
   }
 
   res.render('payment/options', {


### PR DESCRIPTION
In the payment type selection step it uses relative redirects.

This can lead to problems when trailing slashes are appended. It is
safer to use a full absolute redirect so this change addresses that.