### PR TITLE
Update logic and prominence of quote time left

### DIFF
--- a/src/app/views/quote.njk
+++ b/src/app/views/quote.njk
@@ -15,38 +15,31 @@
 
   <h1>Your quote ({{ order.reference }})</h1>
 
+  {% set expiryValue %}
+    {{ quote.expires_on | formatDate }} ({{ quote.expires_on | fromNow }})
+  {% endset %}
+
   {{ MetaList({
     items: [
       { label: 'We sent it on', value: quote.created_on, type: 'datetime' },
+      { label: 'It will expire on', value: expiryValue if not quote.cancelled_on and not quote.expired and not quote.accepted_on },
+      { label: 'You accepted it on', value: quote.accepted_on, type: 'datetime' },
       { label: 'Purchase order (PO) number', value: order.po_number }
     ],
+    modifier: 'stacked',
     itemModifier: 'stacked'
   }) }}
 
-  {% if quote.cancelled_on %}
+  {% if quote.expired or quote.cancelled_on %}
     {% call Message({ type: 'error', element: 'div' }) %}
-      <p>This quote is no longer valid.</p>
+      {% if quote.cancelled_on %}
+        <p>This quote is no longer valid.</p>
+      {% else %}
+        <p>This quote expired on {{ quote.expires_on | formatDate }} ({{ quote.expires_on | fromNow }}).</p>
+      {% endif %}
+
       <p>Get in touch with your DIT contact or email <a href="mailto:omis.orders@digital.trade.gov.uk">omis.orders@digital.trade.gov.uk</a>.</p>
     {% endcall %}
-  {% else %}
-    {% if quote.accepted_on %}
-      {{ Message({
-        type: 'success',
-        text: 'You accepted this quote on ' + quote.accepted_on | formatDateTime
-      }) }}
-    {% endif %}
-
-    {% if not quote.accepted_on %}
-      {% call Message({
-        type: 'error' if quote.expired else 'info',
-        element: 'div'
-      }) %}
-        <p>This quote {{ 'expired' if quote.expired else 'will expire' }} on {{ quote.expires_on | formatDate }} ({{ quote.expires_on | fromNow }}).</p>
-        {% if quote.expired %}
-          <p>Get in touch with your DIT contact or email <a href="mailto:omis.orders@digital.trade.gov.uk">omis.orders@digital.trade.gov.uk</a>.</p>
-        {% endif %}
-      {% endcall %}
-    {% endif %}
   {% endif %}
 
   {% if quote.content %}


### PR DESCRIPTION
This change updates the logic and the messaging for the different
states of a quote.

It reduces the prominence of the message when a quote still has time
left and uses the metalist style rather than a large banner.

It also removes the banner for accepted quotes in place of the
metalist style.

## Before

### Valid
![image](https://user-images.githubusercontent.com/3327997/37479466-a4e74f34-2874-11e8-9bb8-e105fce282b0.png)

### Accepted
![image](https://user-images.githubusercontent.com/3327997/37479434-8f756df2-2874-11e8-8b6f-ea24287115f7.png)

### Expired
![image](https://user-images.githubusercontent.com/3327997/37479447-986d15a4-2874-11e8-864b-ddfcc0669ca5.png)

### Cancelled
![image](https://user-images.githubusercontent.com/3327997/37479456-9ebfae12-2874-11e8-990f-fc77bb7b6c22.png)

## After

### Valid
![image](https://user-images.githubusercontent.com/3327997/37479407-8044c4e0-2874-11e8-95ff-773d875afb2b.png)

### Accepted
![image](https://user-images.githubusercontent.com/3327997/37479337-55d842e0-2874-11e8-8bf8-79fa2e5ac48c.png)

### Expired
![image](https://user-images.githubusercontent.com/3327997/37479290-342b2612-2874-11e8-8dd6-44b62e352b66.png)

### Cancelled
![image](https://user-images.githubusercontent.com/3327997/37479303-3b97f204-2874-11e8-8fc0-cbbd7af6712f.png)
