### PR TITLE
Add anchor back to top of terms and conditions

### DIFF
--- a/src/app/views/quote.njk
+++ b/src/app/views/quote.njk
@@ -13,6 +13,7 @@
     }) }}
   {% endif %}
 
+  <a name="terms-and-conditions" id="terms-and-conditions"></a>
   <h1>Your quote ({{ order.reference }})</h1>
 
   {% set expiryValue %}
@@ -50,6 +51,7 @@
         {% call Reveal({ summary: 'View full terms and conditions' }) %}
 {# Ugly indentation is so that markdown spacing is handled correctly #}
 {% markdown %}{{ quote.terms_and_conditions | safe }}{% endmarkdown %}
+          <p><a href="#terms-and-conditions">Back to top</a></p>
         {% endcall %}
       </div>
     </article>


### PR DESCRIPTION
This change adds an anchor link to get back to the top of the terms
and conditions as this section is quite long.