### PR TITLE
Cookie notice

### DIFF
--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -1,5 +1,8 @@
 require('../images/dit-invoice-logo.png')
 
+const cookieMessage = require('./modules/cookie-message')
+cookieMessage('global-cookies-banner', 'seen_cookie_message')
+
 document.addEventListener('DOMContentLoaded', () => {
   const printLinks = document.querySelectorAll('.js-print')
 

--- a/assets/javascripts/modules/cookie-message.js
+++ b/assets/javascripts/modules/cookie-message.js
@@ -1,0 +1,43 @@
+function setCookie (name, value, options = {}) {
+  let cookieString = `${name}=${value}; path=/`
+
+  if (options.days) {
+    const date = new Date()
+    date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000))
+    cookieString = `${cookieString}; expires=${date.toGMTString()}`
+  }
+
+  if (document.location.protocol === 'https:') {
+    cookieString = `${cookieString}; Secure`
+  }
+
+  document.cookie = cookieString
+}
+
+function getCookie (name) {
+  const nameEQ = `${name}=`
+  const cookies = document.cookie.split(';')
+
+  for (let i = 0, len = cookies.length; i < len; i += 1) {
+    let cookie = cookies[i]
+
+    while (cookie.charAt(0) === ' ') {
+      cookie = cookie.substring(1, cookie.length)
+    }
+
+    if (cookie.indexOf(nameEQ) === 0) {
+      return decodeURIComponent(cookie.substring(nameEQ.length))
+    }
+  }
+
+  return null
+}
+
+module.exports = (id, cookieName) => {
+  const banner = document.getElementById(id)
+
+  if (banner && getCookie(cookieName) === null) {
+    banner.style.display = 'block'
+    setCookie(cookieName, 'yes', { days: 28 })
+  }
+}

--- a/assets/stylesheets/objects/base/_notification-banner.scss
+++ b/assets/stylesheets/objects/base/_notification-banner.scss
@@ -8,5 +8,6 @@
 .notification-banner__inner {
   @include site-width-container;
   padding: $default-spacing-unit 0;
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 0;
 }

--- a/assets/stylesheets/trumps/_utility.scss
+++ b/assets/stylesheets/trumps/_utility.scss
@@ -10,7 +10,7 @@
 
 .u-js-hidden {
   .js-enabled & {
-    display: none !important;
+    display: none;
   }
 }
 

--- a/src/app/controllers/cookies.js
+++ b/src/app/controllers/cookies.js
@@ -1,0 +1,3 @@
+module.exports = function (req, res) {
+  res.render('cookies')
+}

--- a/src/app/routers/index.js
+++ b/src/app/routers/index.js
@@ -2,12 +2,14 @@ const router = require('express').Router()
 
 const orderRouter = require('./order')
 const indexController = require('../controllers/index')
+const renderCookies = require('../controllers/cookies')
 const { renderPingdomXml } = require('../controllers/healthcheck')
 const { fetchOrderDetails } = require('../middleware/order')
 const { setAuthToken } = require('../lib/api')
 
 // NOTE: ping has to be defined before the auth token middleware
 router.get('/ping.xml', renderPingdomXml)
+router.get('/cookies', renderCookies)
 router.get('/', indexController)
 
 router.param('publicToken', fetchOrderDetails)

--- a/src/app/views/_layouts/dit-base.njk
+++ b/src/app/views/_layouts/dit-base.njk
@@ -69,7 +69,7 @@
         <div class="notification-banner u-js-hidden u-print-hide" id="global-cookies-banner" role="alert">
           <p class="notification-banner__inner">
             GOV.UK uses cookies to make the site simpler.
-            <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>
+            <a href="/cookies">Find out more about cookies</a>
           </p>
         </div>
       {% endblock %}
@@ -131,7 +131,7 @@
                 <h2 class="u-visually-hidden">Support links</h2>
                 <ul class="list-inline">
                   <li>
-                    <a href="https://www.gov.uk/help/cookies">Cookies</a>
+                    <a href="/cookies">Cookies</a>
                   </li>
                 </ul>
                 {% block body_footer_content_ogl %}

--- a/src/app/views/cookies.njk
+++ b/src/app/views/cookies.njk
@@ -1,0 +1,149 @@
+{% extends '_layouts/omis-base.njk' %}
+
+{% block body_main_content %}
+  <h1>Cookies</h1>
+
+  <p>GOV.UK puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.</p>
+
+  <p>Cookies are used to:</p>
+
+  <ul>
+    <li>measure how you use the website so it can be updated and improved based on your needs</li>
+    <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+  </ul>
+
+  {% call Message({ type: 'muted', element: 'div' }) %}
+    <p>GOV.UK cookies aren’t used to identify you personally.</p>
+  {% endcall %}
+
+  <p>You’ll normally see a message on the site before we store a cookie on your computer.</p>
+
+  <p>Find out more about <a rel="external" href="https://ico.org.uk/for-the-public/online/cookies/">how to manage cookies</a>.</p>
+
+  <h2>How cookies are used on GOV.UK</h2>
+
+  <h3>Measuring website usage (Google Analytics)</h3>
+
+  <p>We use Google Analytics software to collect information about how you use GOV.UK. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example <a rel="external" href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/">improving site search</a>.</p>
+
+  <p>Google Analytics stores information about:</p>
+
+  <ul>
+    <li>the pages you visit on GOV.UK</li>
+    <li>how long you spend on each GOV.UK page</li>
+    <li>how you got to the site</li>
+    <li>what you click on while you’re visiting the site</li>
+  </ul>
+
+  <p>We don’t collect or store your personal information (for example your name or address) so this information can’t be used to identify who you are.</p>
+
+  {% call Message({ type: 'muted', element: 'div' }) %}
+    <p>We don’t allow Google to use or share our analytics data.</p>
+  {% endcall %}
+
+  <p>Google Analytics sets the following cookies:</p>
+
+  <h3>Universal Analytics</h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>_ga</td>
+        <td>This helps us count how many people visit GOV.UK by tracking if you’ve visited before</td>
+        <td>2 years</td>
+      </tr>
+      <tr>
+        <td>_gid</td>
+        <td>This helps us count how many people visit GOV.UK by tracking if you’ve visited before</td>
+        <td>24 hours</td>
+      </tr>
+      <tr>
+        <td>_gat</td>
+        <td>Used to manage the rate at which page view requests are made</td>
+        <td>10 minutes</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Google Analytics</h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>_utma</td>
+        <td>Like _ga, this lets us know if you’ve visited before, so we can count how many of our visitors are new to GOV.UK or to a certain page</td>
+        <td>2 years</td>
+      </tr>
+      <tr>
+        <td>_utmb</td>
+        <td>This works with _utmc to calculate the average length of time you spend on GOV.UK</td>
+        <td>30 minutes</td>
+      </tr>
+      <tr>
+        <td>_utmc</td>
+        <td>This works with _utmb to calculate when you close your browser</td>
+        <td>when you close your browser</td>
+      </tr>
+      <tr>
+        <td>_utmz</td>
+        <td>This tells us how you reached GOV.UK (for example from another website or a search engine)</td>
+        <td>6 months</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Our introductory message</h3>
+
+  <p>You may see a pop-up welcome message when you first visit GOV.UK. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>seen_cookie_message</td>
+        <td>Saves a message to let us know that you’ve seen our cookie message</td>
+        <td>1 month</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Paying by credit or debit card</h3>
+
+  <p>If you choose to pay by credit or debit card we need to store a cookie for your payment session. The content of this is encrypted and never shared.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+        <td>paymentGatewaySession</td>
+        <td>Saves your payment session so we don’t generate a new one each time</td>
+        <td>2 hours</td>
+      </tr>
+    </tbody>
+  </table>
+{% endblock %}


### PR DESCRIPTION
Rather than link to the GOV.UK cookies page which stores different
cookies we need to create our own and link to that instead.

This change also includes support for showing/hiding the cookie banner
depending on whether the user will have seen the cookie message.