### PR TITLE
Overdue dates format

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -75,8 +75,8 @@ const filters = {
     return dateFns.format(parsedDate, format)
   },
 
-  fromNow: (value) => {
-    return moment(value).fromNow()
+  fromNow: (value, removeSuffix = false) => {
+    return moment(value).fromNow(removeSuffix)
   },
 
   removeNilAndEmpty: (collection) => {

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -63,7 +63,7 @@ const filters = {
     return dateFns.format(parsedDate, format)
   },
 
-  formatDateTime: (value, format = formats.dateTimeMedium) => {
+  formatDateTime: (value, format = formats.dateTimeLong) => {
     if (!value) {
       return value
     }

--- a/src/app/middleware/order.js
+++ b/src/app/middleware/order.js
@@ -26,6 +26,7 @@ async function fetchOrderDetails (req, res, next, publicToken) {
     quote.expired = quote.expires_on < new Date()
 
     invoice = await fetch(authToken, `/v3/omis/public/order/${publicToken}/invoice`)
+    invoice.overdue = invoice.payment_due_date < new Date()
   } catch (error) {
     if (error.statusCode !== 404) {
       return next(error)

--- a/src/app/views/_includes/payment-instructions.njk
+++ b/src/app/views/_includes/payment-instructions.njk
@@ -1,0 +1,5 @@
+<p>
+  You will need to pay
+  <a href="/{{ publicToken }}/invoice">the invoice</a>
+  by {{ invoice.payment_due_date | formatDate }} ({{ invoice.payment_due_date | fromNow(invoice.overdue) }}{{ ' overdue' if invoice.overdue }}).
+</p>

--- a/src/app/views/quote-accepted.njk
+++ b/src/app/views/quote-accepted.njk
@@ -16,7 +16,7 @@
 
   <p>You will receive a confirmation email that the quote has been accepted.</p>
 
-  <p>You will need to pay <a href="/{{ publicToken }}/invoice">the invoice</a> by {{ invoice.payment_due_date | formatDate }} ({{ invoice.payment_due_date | fromNow }}).</p>
+  {% include '_includes/payment-instructions.njk' %}
 
   <p>
     <a href="/{{ publicToken }}">Return to summary</a>


### PR DESCRIPTION
This change allows us to display overdue payment dates in a better format.

## Before

`You will need to pay the invoice by 14 April 2018 (24 days ago).`

## After

`You will need to pay the invoice by 14 April 2018 (24 overdue).`