### PR TITLE
Set correct date for payment receipt

### DIFF
--- a/src/app/views/_layouts/invoice.njk
+++ b/src/app/views/_layouts/invoice.njk
@@ -38,7 +38,7 @@
           { label: 'VAT number', value: order.vat_number },
           { label: 'Purchase order (PO) number', value: invoice.po_number },
           { label: 'Invoice number', value: invoice.invoice_number },
-          { label: creationDateLabel | default('Invoice date'), value: invoice.created_on, type: 'datetime' }
+          { label: creationDateLabel | default('Invoice date'), value: creationDateValue | default(invoice.created_on), type: 'date' }
         ],
         modifier: 'stacked',
         itemModifier: 'stacked'

--- a/src/app/views/receipt.njk
+++ b/src/app/views/receipt.njk
@@ -2,6 +2,7 @@
 
 {% set heading = 'Receipt' %}
 {% set creationDateLabel = 'Receipt date' %}
+{% set creationDateValue = order.paid_on %}
 
 {% block invoice_payment_information %}
   <h2 class="heading-medium">


### PR DESCRIPTION
It was previously using the invoice date on the payment receipt.

This change makes the receipt date come from the order paid_on value.