### PR TITLE
Skip failure page on expected error journeys

### DIFF
--- a/src/app/routers/payment.js
+++ b/src/app/routers/payment.js
@@ -26,7 +26,7 @@ router.get('/card/success', setPayments, renderCardSuccess)
 router.get('/card/:paymentSessionId',
   validatePaymentGatewaySession,
   setPaymentGatewaySession,
-  checkPaymentGatewaySessionStatus,
+  checkPaymentGatewaySessionStatus(true),
   redirectReturnUrl
 )
 
@@ -44,7 +44,7 @@ router.get('/bank-transfer', renderBankTransferMethod)
 router.get('/card',
   createPaymentGatewaySession,
   setPaymentGatewaySession,
-  checkPaymentGatewaySessionStatus,
+  checkPaymentGatewaySessionStatus(),
   renderCardMethod
 )
 


### PR DESCRIPTION
The GOV.UK Pay contains an error page for each scenario. Currently
in all these scenarios we redirect to an error page on our service.

This caused some issues with users as to them, they are seeing two
very similar error pages and we are making them experience the same
page twice.

This felt very unnecessary so for the expected error scenarios on the
return journey from GOV.UK Pay we can bypass this page and go straight
to the card payment screen again.