### PR TITLE
Display links in print view

### DIFF
--- a/assets/stylesheets/app.print.scss
+++ b/assets/stylesheets/app.print.scss
@@ -1,3 +1,25 @@
 $is-print: true;
 
+a[href^="/"],
+a[href^="http://"],
+a[href^="https://"] {
+  &:after {
+    content: " (" attr(href) ")";
+    font-size: 90%;
+  }
+}
+
+a[href^="/"]:after {
+  content: " (https://omis.trade.gov.uk/" attr(href) ")";
+  font-size: 90%;
+}
+
+a[href^="javascript:"],
+a[href^="#"],
+a.global-header__link {
+  &:after {
+    content: "";
+  }
+}
+
 @import "app";


### PR DESCRIPTION
This change adds a bit of CSS to use the value of the href attribute
to output the link destination when printing.

This allows people to still be able to visit the URL if they only have
a printed copy of the page.

## Before

![image](https://user-images.githubusercontent.com/3327997/37903145-c4e473f2-30ee-11e8-809e-e0c8f5502396.png)

## After

![image](https://user-images.githubusercontent.com/3327997/37903126-b6a92602-30ee-11e8-85b8-5a875e62667d.png)
