### PR TITLE
Handle 404 correctly

### DIFF
--- a/src/app/middleware/errors.js
+++ b/src/app/middleware/errors.js
@@ -9,7 +9,7 @@ module.exports = {
   },
 
   catchAll: function (error, req, res, next) {
-    const statusCode = error.statusCode = (error.statusCode || 500)
+    const statusCode = error.statusCode = (error.response ? error.response.status : error.statusCode) || 500
     let statusMessage = statusCode === 404
       ? 'We couldn\'t find that page'
       : 'Something has gone wrong'

--- a/src/test/app/specs/middleware/errors.spec.js
+++ b/src/test/app/specs/middleware/errors.spec.js
@@ -53,7 +53,25 @@ describe('errors middleware', function () {
         describe('When error code is 404', function () {
           it('Should log the error and send a response with the right status code', function () {
             err.statusCode = 404
+            middleware.catchAll(err, req, res, next)
 
+            expect(res.status).toHaveBeenCalledWith(404)
+            expect(res.render).toHaveBeenCalledWith('errors', {
+              error: err,
+              statusCode: 404,
+              statusMessage: 'We couldn\'t find that page',
+              showErrors: config.showErrors,
+            })
+            expect(logger.error).not.toHaveBeenCalled()
+            expect(next).not.toHaveBeenCalled()
+          })
+        })
+
+        describe('When axios returns an error with response status 404', function () {
+          it('Should log the error and send a response with the right status code', function () {
+            err.response = {
+              status: 404,
+            }
             middleware.catchAll(err, req, res, next)
 
             expect(res.status).toHaveBeenCalledWith(404)
@@ -108,7 +126,6 @@ describe('errors middleware', function () {
       it('Should call next with error', function () {
         const expectedError = new Error('Not Found')
         expectedError.statusCode = 404
-
         middleware.handle404(req, res, next)
 
         expect(next).toHaveBeenCalledWith(expectedError)


### PR DESCRIPTION
This fixes an issue where 404 errors were showing as 500 and creating noise in Sentry.

