### PR TITLE
Rollback date-fns upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+    - dependency-name: date-fns 
+    versions:
+      - "> 2.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "cookie-parser": "^1.4.3",
         "css-loader": "^6.10.0",
         "csurf": "^1.9.0",
-        "date-fns": "^3.0.6",
+        "date-fns": "^2.3.0",
         "del-cli": "^5.1.0",
         "dotenv": "^16.4.4",
         "express": "^4.16.3",
@@ -4554,13 +4554,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.0.6.tgz",
-      "integrity": "sha512-W+G99rycpKMMF2/YD064b2lE7jJGUe+EjOES7Q8BIGY8sbNdbgcs9XFTZwvzc9Jx1f3k7LB7gZaZa7f8Agzljg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.3.0.tgz",
+      "integrity": "sha512-A8o+iXBVqQayl9Z39BHgb7m/zLOfhF7LK82t+n9Fq1adds1vaUn8ByVoADqWLe4OTc6BZYc/FdbdTwufNYqkJw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cookie-parser": "^1.4.3",
     "css-loader": "^6.10.0",
     "csurf": "^1.9.0",
-    "date-fns": "^3.0.6",
+    "date-fns": "^2.3.0",
     "del-cli": "^5.1.0",
     "dotenv": "^16.4.4",
     "express": "^4.16.3",


### PR DESCRIPTION
We had an outage this morning with the OMIS frontend caused by a broken dependency upgrade. This has been rolled back and is now on the Dependabot ignore list.