### PR TITLE
Update Omis frontend - health check

### DIFF
--- a/src/app/controllers/healthcheck.js
+++ b/src/app/controllers/healthcheck.js
@@ -5,7 +5,7 @@ const logger = require('../lib/logger')
 const serviceDependencies = [
   {
     name: 'leeloo',
-    healthCheck: () => axios.get(`${api.root}/ping.xml`),
+    healthCheck: () => axios.get(`${api.root}/pingdom/ping.xml`),
   },
 ]
 

--- a/src/app/routers/index.js
+++ b/src/app/routers/index.js
@@ -7,7 +7,7 @@ const { renderPingdomXml } = require('../controllers/healthcheck')
 const { fetchOrderDetails } = require('../middleware/order')
 
 // NOTE: ping has to be defined before the auth token middleware
-router.get('/ping.xml', renderPingdomXml)
+router.get('/pingdom/ping.xml', renderPingdomXml)
 router.get('/cookies', renderCookies)
 router.get('/', indexController)
 


### PR DESCRIPTION
## Changes
Renamed health check end point from /ping.xml to /pingdom/ping.xml.

Also call the updated end point on the Data Hub API (matching `migration-deploy` branch). 

Test are to be written as part of TET-664.

## Test instructions
Run OMIS front end and connect to local/docker Data Hub API running `migration-deploy` branch. Accessing location:4000/pingdom/ping.xml should accurately reflect state of system.

When systems are running as expected, it should return status code 200 and 
```
<pingdom_http_custom_check>
<status>OK</status>
<response_time>#</response_time>
</pingdom_http_custom_check>
```

When Data Hub API isn't running as expected it should return status code 503 and
```
<pingdom_http_custom_check>
<status>Service Unavailable</status>
<response_time>#</response_time>
</pingdom_http_custom_check>
```