### PR TITLE
Remove deprecated environment variables

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,15 +6,6 @@
     "SESSION_SECRET": {
       "generator": "secret"
     },
-    "API_CLIENT_ID": {
-      "required": true
-    },
-    "API_CLIENT_SCOPE": {
-      "required": true
-    },
-    "API_CLIENT_SECRET": {
-      "required": true
-    },
     "API_ROOT": {
       "required": true
     }


### PR DESCRIPTION
Removing unused environment variables (for the PaaS migration) that seem to have been set up for the Heroku infrastructure. 