### PR TITLE
Fix/flaky e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   e2e_tests:
     machine:
       image: ubuntu-2004:2024.01.1
-      docker_layer_caching: true
+      docker_layer_caching: false
     parallelism: 1
     resource_class: xlarge
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   e2e_tests:
     machine:
       image: ubuntu-2004:2024.01.1
-      docker_layer_caching: false
+      docker_layer_caching: true
     parallelism: 1
     resource_class: xlarge
     steps:

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -5,7 +5,7 @@ services:
       - api
 
   api:
-    image: gcr.io/sre-docker-registry/data-hub-api:latest
+    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:main
     env_file: .env
     environment:
       DEBUG: 'False'

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -5,7 +5,7 @@ services:
       - api
 
   api:
-    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:main
+    image: gcr.io/sre-docker-registry/data-hub-api:latest
     env_file: .env
     environment:
       DEBUG: 'False'

--- a/test/end-to-end/cypress/order-page-spec.cy.js
+++ b/test/end-to-end/cypress/order-page-spec.cy.js
@@ -1,4 +1,4 @@
-const { addMonths, format } = require('date-fns')
+const { format, addDays } = require('date-fns')
 
 const { formats } = require('../../../config')
 
@@ -36,7 +36,7 @@ describe('order page spec', () => {
       .and('contain', 'It will expire on')
       .and(
         'contain',
-        `${format(addMonths(new Date(), 1), formats.dateLong)} (in a month)`
+        `${format(addDays(new Date(), 30), formats.dateLong)} (in a month)`
       )
   })
   it('when visiting an order where the quote is accepted', () => {
@@ -58,7 +58,7 @@ describe('order page spec', () => {
     )
     cy.get('[data-test="pay-invoice-text"]').should(
       'have.text',
-      `\n  You will need to pay\n  the invoice\n  by ${format(addMonths(new Date(), 1), formats.dateLong)} (in a month).\n`
+      `\n  You will need to pay\n  the invoice\n  by ${format(addDays(new Date(), 30), formats.dateLong)} (in a month).\n`
     )
     cy.get('[data-test="invoice-link"]')
       .should('have.text', 'the invoice')

--- a/test/end-to-end/cypress/quote-accepted-spec.cy.js
+++ b/test/end-to-end/cypress/quote-accepted-spec.cy.js
@@ -1,4 +1,4 @@
-const { addMonths, format } = require('date-fns')
+const { format, addDays } = require('date-fns')
 
 const { formats } = require('../../../config')
 
@@ -20,7 +20,7 @@ describe('quote acceptance page spec', () => {
     )
     cy.get('[data-test="pay-invoice-text"]').should(
       'have.text',
-      `\n  You will need to pay\n  the invoice\n  by ${format(addMonths(new Date(), 1), formats.dateLong)} (in a month).\n`
+      `\n  You will need to pay\n  the invoice\n  by ${format(addDays(new Date(), 30), formats.dateLong)} (in a month).\n`
     )
     cy.get('[data-test="payment-options-button"]')
       .should('contain', 'View payment options')

--- a/test/end-to-end/cypress/quote-page-spec.cy.js
+++ b/test/end-to-end/cypress/quote-page-spec.cy.js
@@ -1,4 +1,4 @@
-const { addMonths, format } = require('date-fns')
+const { format, addDays } = require('date-fns')
 
 const { formats } = require('../../../config')
 
@@ -26,7 +26,7 @@ describe('quote page spec', () => {
       .and('contain', 'It will expire on')
       .and(
         'contain',
-        `${format(addMonths(new Date(), 1), formats.dateLong)} (in a month)`
+        `${format(addDays(new Date(), 30), formats.dateLong)} (in a month)`
       )
 
     cy.log('should render quote')
@@ -50,7 +50,7 @@ describe('quote page spec', () => {
       )
       .and(
         'contain',
-        `This Quote must be accepted by you by ${format(addMonths(new Date(), 1), formats.dateLong)}.`
+        `This Quote must be accepted by you by ${format(addDays(new Date(), 30), formats.dateLong)}.`
       )
 
     cy.log('should render the quote acceptance elements')
@@ -126,7 +126,7 @@ describe('quote page spec', () => {
       )
       .and(
         'contain',
-        `This Quote must be accepted by you by ${format(addMonths(new Date(), 1), formats.dateLong)}.`
+        `This Quote must be accepted by you by ${format(addDays(new Date(), 30), formats.dateLong)}.`
       )
 
     cy.log('should not display the acceptance elements')


### PR DESCRIPTION
e2e tests were failing because they were checking for dates 1 month from the day the tests were run for dates invoices should be paid. However, in the api we set it to be 30 days. 